### PR TITLE
fix: Better handle fractional setpoints

### DIFF
--- a/components/aux_ac/aux_ac.h
+++ b/components/aux_ac/aux_ac.h
@@ -1712,7 +1712,7 @@ class AirCon : public esphome::Component, public esphome::climate::Climate {
             pack->body[2] = (pack->body[2] & ~AC_TEMP_TARGET_INT_PART_MASK) | (((uint8_t)(cmd->temp_target) - 8) << 3);
 
             // дробная часть температуры
-            if (cmd->temp_target - (uint8_t)(cmd->temp_target) > 0) {
+            if (cmd->temp_target - (uint8_t)(cmd->temp_target) >= 0.5) {
                 pack->body[4] = (pack->body[4] | AC_TEMP_TARGET_FRAC_PART_MASK);
             } else {
                 pack->body[4] = (pack->body[4] & ~AC_TEMP_TARGET_FRAC_PART_MASK);


### PR DESCRIPTION
Hi - apologies for dropping in on this PR unannounced. I recently got this working with my `AUX ASW-H12U3/JIR1DI-US` air conditioner, but noticed an issue when adjusting the temperature setpoint in Home Assistant.

Because I'm US-based, my unit of choice is Fahrenheit, and setting the temperature would cause some unpredictable jumping:

![firefox_sHZNo9VcxC](https://github.com/GrKoR/esphome_aux_ac_component/assets/5192145/ee639327-0f13-4df7-b0a5-e16f00b09eae)

A brief analysis seems to show that the setpoint was being rounded improperly:

```
[D][climate:011]: 'AUX AC' - Setting
[D][climate:040]:   Target Temperature: 22.22
...
[V][AirCon:2408]: Target temperature: 22.500000
```

This change will only set the fractional flag if the setpoint is actually a value of 0.5 or higher, which appears to have resolved the issue on my end. I'm not particularly sure what (if anything) this will negatively impact elsewhere in the project, but would still like to propose my changes nonetheless.

I will also note that the temperature displayed on my unit is in Celsius whenever set through the API, but that seems tolerable for now and would likely require additional RE work of the protocol to find that flag.