### PR TITLE
feat: support esp-idf

### DIFF
--- a/components/aux_ac/aux_ac.h
+++ b/components/aux_ac/aux_ac.h
@@ -4,8 +4,10 @@
 /// немного переработанная версия старого компонента
 #pragma once
 
-#include <Arduino.h>
 #include <stdarg.h>
+#ifndef F
+#define F(string_literal) (string_literal)  
+#endif
 
 #include "esphome.h"
 #include "esphome/components/binary_sensor/binary_sensor.h"
@@ -15,6 +17,8 @@
 #include "esphome/components/uart/uart.h"
 #include "esphome/core/component.h"
 #include "esphome/core/helpers.h"
+
+using String = std::string;
 
 // весь функционал сохранения пресетов прячу под дефайн
 //  #define PRESETS_SAVING

--- a/components/aux_ac/aux_ac.h
+++ b/components/aux_ac/aux_ac.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <stdarg.h>
+#include <cinttypes>
 #ifndef F
 #define F(string_literal) (string_literal)  
 #endif
@@ -1714,7 +1715,7 @@ namespace esphome
 
                 // заполняем время получения пакета
                 memset(textBuf, 0, 11);
-                sprintf(textBuf, "%010u", packet->msec);
+                sprintf(textBuf, "%010" PRIu32, packet->msec);
                 st = st + textBuf + ": ";
 
                 // формируем преамбулы
@@ -2843,11 +2844,11 @@ namespace esphome
             {
                 ESP_LOGCONFIG(TAG, "AUX HVAC:");
                 ESP_LOGCONFIG(TAG, "  [x] Firmware version: %s", Constants::AC_FIRMWARE_VERSION.c_str());
-                ESP_LOGCONFIG(TAG, "  [x] Period: %dms", this->get_period());
+                ESP_LOGCONFIG(TAG, "  [x] Period: %" PRIu32 "ms", this->get_period());
                 ESP_LOGCONFIG(TAG, "  [x] Show action: %s", TRUEFALSE(this->get_show_action()));
                 ESP_LOGCONFIG(TAG, "  [x] Display inverted: %s", TRUEFALSE(this->get_display_inverted()));
                 ESP_LOGCONFIG(TAG, "  [x] Optimistic: %s", TRUEFALSE(this->get_optimistic()));
-                ESP_LOGCONFIG(TAG, "  [x] Packet timeout: %dms", this->get_packet_timeout());
+                ESP_LOGCONFIG(TAG, "  [x] Packet timeout: %" PRIu32 "ms", this->get_packet_timeout());
 
 #if defined(PRESETS_SAVING)
                 ESP_LOGCONFIG(TAG, "  [x] Save settings %s", TRUEFALSE(this->get_store_settings()));


### PR DESCRIPTION
Removing the dependency in Arduino.h which was used only for debugging.
fixing some wrong types that made compilation problems in my esp32-c6 - probably due to a newer compiler.

note: this is kind of hacky, but I managed to compile it.
might need some more effort to make sure that it works now both on older esp32 and newer ones, and maybe having a "real" F macro.