### PR TITLE
Fix ESPHome 2026.x compatibility: synchronous= warning and ClimateTraits deprecation

### DIFF
--- a/components/aux_ac/aux_ac.h
+++ b/components/aux_ac/aux_ac.h
@@ -3790,8 +3790,11 @@ namespace esphome
                 _traits.set_supported_modes(this->_supported_modes);
                 _traits.set_supported_swing_modes(this->_supported_swing_modes);
                 _traits.set_supported_presets(this->_supported_presets);
-                _traits.set_supported_custom_presets(this->_supported_custom_presets);
-                _traits.set_supported_custom_fan_modes(this->_supported_custom_fan_modes);
+                // ESPHome moved these setters from ClimateTraits to Climate
+                // in 2026.x; the traits versions are deprecated and slated for
+                // removal in 2026.11.0. Same signature, just a different host.
+                this->set_supported_custom_presets(this->_supported_custom_presets);
+                this->set_supported_custom_fan_modes(this->_supported_custom_fan_modes);
 
                 // tells the frontend what range of temperatures the climate device should display (gauge min/max values)
                 // TODO: GK: а вот здесь похоже неправильно. Похоже, так мы не сможем выставить в конфиге свой диапазон температур - всегда будет от AC_MIN_TEMPERATURE до AC_MAX_TEMPERATURE

--- a/components/aux_ac/climate.py
+++ b/components/aux_ac/climate.py
@@ -441,7 +441,10 @@ DISPLAY_ACTION_SCHEMA = maybe_simple_id(
 
 
 @automation.register_action(
-    "aux_ac.display_off", AirConDisplayOffAction, DISPLAY_ACTION_SCHEMA
+    "aux_ac.display_off",
+    AirConDisplayOffAction,
+    DISPLAY_ACTION_SCHEMA,
+    synchronous=True,
 )
 async def display_off_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
@@ -449,7 +452,10 @@ async def display_off_to_code(config, action_id, template_arg, args):
 
 
 @automation.register_action(
-    "aux_ac.display_on", AirConDisplayOnAction, DISPLAY_ACTION_SCHEMA
+    "aux_ac.display_on",
+    AirConDisplayOnAction,
+    DISPLAY_ACTION_SCHEMA,
+    synchronous=True,
 )
 async def display_on_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
@@ -464,7 +470,10 @@ VLOUVER_ACTION_SCHEMA = maybe_simple_id(
 
 
 @automation.register_action(
-    "aux_ac.vlouver_stop", AirConVLouverStopAction, VLOUVER_ACTION_SCHEMA
+    "aux_ac.vlouver_stop",
+    AirConVLouverStopAction,
+    VLOUVER_ACTION_SCHEMA,
+    synchronous=True,
 )
 async def vlouver_stop_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
@@ -472,7 +481,10 @@ async def vlouver_stop_to_code(config, action_id, template_arg, args):
 
 
 @automation.register_action(
-    "aux_ac.vlouver_swing", AirConVLouverSwingAction, VLOUVER_ACTION_SCHEMA
+    "aux_ac.vlouver_swing",
+    AirConVLouverSwingAction,
+    VLOUVER_ACTION_SCHEMA,
+    synchronous=True,
 )
 async def vlouver_swing_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
@@ -480,7 +492,10 @@ async def vlouver_swing_to_code(config, action_id, template_arg, args):
 
 
 @automation.register_action(
-    "aux_ac.vlouver_top", AirConVLouverTopAction, VLOUVER_ACTION_SCHEMA
+    "aux_ac.vlouver_top",
+    AirConVLouverTopAction,
+    VLOUVER_ACTION_SCHEMA,
+    synchronous=True,
 )
 async def vlouver_top_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
@@ -488,7 +503,10 @@ async def vlouver_top_to_code(config, action_id, template_arg, args):
 
 
 @automation.register_action(
-    "aux_ac.vlouver_middle_above", AirConVLouverMiddleAboveAction, VLOUVER_ACTION_SCHEMA
+    "aux_ac.vlouver_middle_above",
+    AirConVLouverMiddleAboveAction,
+    VLOUVER_ACTION_SCHEMA,
+    synchronous=True,
 )
 async def vlouver_middle_above_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
@@ -496,7 +514,10 @@ async def vlouver_middle_above_to_code(config, action_id, template_arg, args):
 
 
 @automation.register_action(
-    "aux_ac.vlouver_middle", AirConVLouverMiddleAction, VLOUVER_ACTION_SCHEMA
+    "aux_ac.vlouver_middle",
+    AirConVLouverMiddleAction,
+    VLOUVER_ACTION_SCHEMA,
+    synchronous=True,
 )
 async def vlouver_middle_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
@@ -504,7 +525,10 @@ async def vlouver_middle_to_code(config, action_id, template_arg, args):
 
 
 @automation.register_action(
-    "aux_ac.vlouver_middle_below", AirConVLouverMiddleBelowAction, VLOUVER_ACTION_SCHEMA
+    "aux_ac.vlouver_middle_below",
+    AirConVLouverMiddleBelowAction,
+    VLOUVER_ACTION_SCHEMA,
+    synchronous=True,
 )
 async def vlouver_middle_below_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
@@ -512,7 +536,10 @@ async def vlouver_middle_below_to_code(config, action_id, template_arg, args):
 
 
 @automation.register_action(
-    "aux_ac.vlouver_bottom", AirConVLouverBottomAction, VLOUVER_ACTION_SCHEMA
+    "aux_ac.vlouver_bottom",
+    AirConVLouverBottomAction,
+    VLOUVER_ACTION_SCHEMA,
+    synchronous=True,
 )
 async def vlouver_bottom_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
@@ -528,7 +555,10 @@ VLOUVER_SET_ACTION_SCHEMA = cv.Schema(
 
 
 @automation.register_action(
-    "aux_ac.vlouver_set", AirConVLouverSetAction, VLOUVER_SET_ACTION_SCHEMA
+    "aux_ac.vlouver_set",
+    AirConVLouverSetAction,
+    VLOUVER_SET_ACTION_SCHEMA,
+    synchronous=True,
 )
 async def vlouver_set_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
@@ -546,7 +576,10 @@ POWER_LIMITATION_OFF_ACTION_SCHEMA = maybe_simple_id(
 
 
 @automation.register_action(
-    "aux_ac.power_limit_off", AirConPowerLimitationOffAction, POWER_LIMITATION_OFF_ACTION_SCHEMA
+    "aux_ac.power_limit_off",
+    AirConPowerLimitationOffAction,
+    POWER_LIMITATION_OFF_ACTION_SCHEMA,
+    synchronous=True,
 )
 async def power_limit_off_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
@@ -562,7 +595,10 @@ POWER_LIMITATION_ON_ACTION_SCHEMA = cv.Schema(
 
 
 @automation.register_action(
-    "aux_ac.power_limit_on", AirConPowerLimitationOnAction, POWER_LIMITATION_ON_ACTION_SCHEMA
+    "aux_ac.power_limit_on",
+    AirConPowerLimitationOnAction,
+    POWER_LIMITATION_ON_ACTION_SCHEMA,
+    synchronous=True,
 )
 async def power_limit_on_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
@@ -587,7 +623,10 @@ SEND_TEST_PACKET_ACTION_SCHEMA = maybe_simple_id(
 
 
 @automation.register_action(
-    "aux_ac.send_packet", AirConSendTestPacketAction, SEND_TEST_PACKET_ACTION_SCHEMA
+    "aux_ac.send_packet",
+    AirConSendTestPacketAction,
+    SEND_TEST_PACKET_ACTION_SCHEMA,
+    synchronous=True,
 )
 async def send_packet_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])


### PR DESCRIPTION
Two ESPHome 2026.x compatibility fixes, no runtime behavior change.

## 1. `register_action()` — `synchronous=True`

ESPHome added a `synchronous=` parameter on `register_action()` that enables a StringRef optimization for actions whose `play()` is fully synchronous. When omitted, ESPHome warns (1 per registered action) and defaults to `synchronous=False`.

All 13 actions in this component follow the same pattern: `play()` invokes an `AirCon::*Sequence()` method that synchronously enqueues a packet to the internal TX buffer and returns. None defer to a timer, callback, or `loop()`. So `play_next_()` runs synchronously within `play_complex()` — the `synchronous=True` contract.

Affected actions: `aux_ac.display_off`, `aux_ac.display_on`, `aux_ac.vlouver_stop`, `aux_ac.vlouver_swing`, `aux_ac.vlouver_top`, `aux_ac.vlouver_middle_above`, `aux_ac.vlouver_middle`, `aux_ac.vlouver_middle_below`, `aux_ac.vlouver_bottom`, `aux_ac.vlouver_set`, `aux_ac.power_limit_off`, `aux_ac.power_limit_on`, `aux_ac.send_packet`.

## 2. `set_supported_custom_{presets,fan_modes}` — move off `ClimateTraits`

ESPHome 2026.x moved these setters from `ClimateTraits` to the `Climate` entity. The traits versions are marked `[[deprecated]]` and scheduled for removal in 2026.11.0:

```
warning: 'void esphome::climate::ClimateTraits::set_supported_custom_presets(...)' is deprecated:
  Call set_supported_custom_presets() on the Climate entity instead. Removed in 2026.11.0
```

Same signature (`const std::vector<const char *> &`), just a different host. Switching from `_traits.set_*` to `this->set_*` silences `-Wdeprecated-declarations` and keeps the component compiling past 2026.11.

## Testing

Compiled against ESPHome 2026.4.5 with a Tornado Smart-Inv-32 (ESP8266 / esp12e). All previous `register_action` warnings gone, both `set_supported_custom_*` deprecation warnings gone, firmware boots, climate entity exposes presets and custom fan modes as before.