### PR TITLE
fix: fall back to target_temp_frac_bool when target_temp_frac_dec is 0

### DIFF
--- a/components/aux_ac/aux_ac.h
+++ b/components/aux_ac/aux_ac.h
@@ -1447,8 +1447,7 @@ namespace esphome
                         small_info_body = (packet_small_info_body_t *)(_inPacket.body);
 
                         // в малом пакете передается большое количество установленных пользователем параметров работы
-                        // stateFloat = 8.0 + (float)(small_info_body->target_temp_int) + ((small_info_body->target_temp_frac_bool) ? 0.5 : 0.0);
-                        stateFloat = 8.0 + (float)(small_info_body->target_temp_int) + (small_info_body->target_temp_frac_dec / 10.0);
+                        stateFloat = 8.0 + (float)(small_info_body->target_temp_int) + (small_info_body->target_temp_frac_dec > 0 ? (small_info_body->target_temp_frac_dec / 10.0) : (small_info_body->target_temp_frac_bool ? 0.5 : 0.0));
                         stateChangedFlag = stateChangedFlag || (_current_ac_state.temp_target != stateFloat);
                         _current_ac_state.temp_target = stateFloat;
                         _current_ac_state.temp_target_matter = true;


### PR DESCRIPTION
Some AUX AC models report the fractional part of the target temperature via the boolean flag `target_temp_frac_bool` (a single bit at byte 12) rather than the dedicated `target_temp_frac_dec` byte (byte 22).

When `target_temp_frac_dec` is 0, the code now falls back to checking `target_temp_frac_bool` — if set, 0.5 is added to the integer part. This prevents the target temperature from being incorrectly reported as always having .0 when it should have .5 on affected units.