### PR TITLE
Revert "fix: fall back to target_temp_frac_bool when target_temp_frac_dec is 0"

### DIFF
--- a/components/aux_ac/aux_ac.h
+++ b/components/aux_ac/aux_ac.h
@@ -1447,7 +1447,8 @@ namespace esphome
                         small_info_body = (packet_small_info_body_t *)(_inPacket.body);
 
                         // в малом пакете передается большое количество установленных пользователем параметров работы
-                        stateFloat = 8.0 + (float)(small_info_body->target_temp_int) + (small_info_body->target_temp_frac_dec > 0 ? (small_info_body->target_temp_frac_dec / 10.0) : (small_info_body->target_temp_frac_bool ? 0.5 : 0.0));
+                        // stateFloat = 8.0 + (float)(small_info_body->target_temp_int) + ((small_info_body->target_temp_frac_bool) ? 0.5 : 0.0);
+                        stateFloat = 8.0 + (float)(small_info_body->target_temp_int) + (small_info_body->target_temp_frac_dec / 10.0);
                         stateChangedFlag = stateChangedFlag || (_current_ac_state.temp_target != stateFloat);
                         _current_ac_state.temp_target = stateFloat;
                         _current_ac_state.temp_target_matter = true;


### PR DESCRIPTION
Reverts GrKoR/esphome_aux_ac_component#221

There are reports from community that for some ACs the target temperature started randomly drifting away from the user-set value.
Revert the PR to troubleshoot that